### PR TITLE
Refactor mockProvider setup in provider_test.go

### DIFF
--- a/pkg/storage/provider_test.go
+++ b/pkg/storage/provider_test.go
@@ -12,6 +12,29 @@ import (
 
 var errFailedToUpload = errors.New("failed to upload")
 
+type mockProvider struct {
+	mockUpload   func(ctx context.Context, file *types.File) (*types.File, error)
+	mockDownload func(ctx context.Context, key string) ([]byte, error)
+	mockDelete   func(ctx context.Context, key string) error
+}
+
+func (mp *mockProvider) Upload(ctx context.Context, file *types.File) (*types.File, error) {
+	return mp.mockUpload(ctx, file)
+}
+
+func (mp *mockProvider) Download(ctx context.Context, key string) ([]byte, error) {
+	return mp.mockDownload(ctx, key)
+}
+
+func (mp *mockProvider) Delete(ctx context.Context, key string) error {
+	return mp.mockDelete(ctx, key)
+}
+
+// NewMock is a helper function to create a Manager with a mock Provider.
+func newMock(mockProvider storage.Provider) *storage.Manager {
+	return &storage.Manager{Provider: mockProvider}
+}
+
 func TestNewProviderManager(t *testing.T) {
 	t.Parallel()
 
@@ -64,29 +87,6 @@ func TestNewProviderManager(t *testing.T) {
 			}
 		})
 	}
-}
-
-type mockProvider struct {
-	mockUpload   func(ctx context.Context, file *types.File) (*types.File, error)
-	mockDownload func(ctx context.Context, key string) ([]byte, error)
-	mockDelete   func(ctx context.Context, key string) error
-}
-
-func (mp *mockProvider) Upload(ctx context.Context, file *types.File) (*types.File, error) {
-	return mp.mockUpload(ctx, file)
-}
-
-func (mp *mockProvider) Download(ctx context.Context, key string) ([]byte, error) {
-	return mp.mockDownload(ctx, key)
-}
-
-func (mp *mockProvider) Delete(ctx context.Context, key string) error {
-	return mp.mockDelete(ctx, key)
-}
-
-// NewMock is a helper function to create a Manager with a mock Provider.
-func newMock(mockProvider storage.Provider) *storage.Manager {
-	return &storage.Manager{Provider: mockProvider}
 }
 
 func TestUpload(t *testing.T) {


### PR DESCRIPTION
The mockProvider setup has been relocated and deduplicated within the test file. This improves clarity and avoids redundant code, ensuring better maintainability and readability of the tests.