### PR TITLE
Add unit test for local storage provider creation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,8 +18,6 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    env:
-      LOCAL_PATH: "./"
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,8 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    env:
+      LOCAL_PATH: "./"
     steps:
       - uses: actions/checkout@v4
 

--- a/.idea/go.imports.xml
+++ b/.idea/go.imports.xml
@@ -3,6 +3,7 @@
   <component name="GoImports">
     <option name="excludedPackages">
       <array>
+        <option value="gosdk/pkg/storage/local" />
         <option value="testing" />
       </array>
     </option>

--- a/pkg/storage/local/provider.go
+++ b/pkg/storage/local/provider.go
@@ -3,16 +3,22 @@ package local
 import (
 	"context"
 	"errors"
-
 	"gosdk/internal/types"
+	"os"
 )
 
-var errNotImplemented = errors.New("not implemented")
+var errMissingLocalPath = errors.New("missing env LOCAL_PATH")
 
-type Provider struct{}
+type Provider struct {
+	basePath string
+}
 
 func NewProvider() (*Provider, error) {
-	return nil, errNotImplemented
+	if os.Getenv("LOCAL_PATH") == "" {
+		return nil, errMissingLocalPath
+	}
+
+	return &Provider{basePath: os.Getenv("LOCAL_PATH")}, nil
 }
 
 func (p *Provider) Upload(ctx context.Context, file *types.File) (*types.File, error) {

--- a/pkg/storage/local/provider.go
+++ b/pkg/storage/local/provider.go
@@ -3,8 +3,9 @@ package local
 import (
 	"context"
 	"errors"
-	"gosdk/internal/types"
 	"os"
+
+	"gosdk/internal/types"
 )
 
 var errMissingLocalPath = errors.New("missing env LOCAL_PATH")

--- a/pkg/storage/local/provider_test.go
+++ b/pkg/storage/local/provider_test.go
@@ -1,52 +1,29 @@
 package local_test
 
 import (
-	"errors"
-	"fmt"
-	"os"
 	"testing"
 
 	sdktesting "gosdk/internal/testing"
 	"gosdk/pkg/storage/local"
 )
 
-var errMissingEnvironmentVariable = errors.New("missing environment variable")
-
-func checkEnvVariables(provider string, variables []string) error {
-	for _, v := range variables {
-		if os.Getenv(v) == "" {
-			return fmt.Errorf("%w: %s provider, variable %s", errMissingEnvironmentVariable, provider, v)
-		}
-	}
-
-	return nil
-}
-
-func setupEnv() error {
-	return checkEnvVariables("local", []string{"LOCAL_PATH"})
-}
-
-func TestNewProvider(t *testing.T) {
-	t.Parallel()
-
+func TestNewProviderSuccess(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		t.Parallel()
-
-		err := os.Setenv("LOCAL_PATH", "/tmp")
-		sdktesting.IsNull(t, err)
+		t.Setenv("LOCAL_PATH", "/tmp")
 
 		localProvider, err := local.NewProvider()
 		sdktesting.IsNull(t, err)
 		sdktesting.IsNotNull(t, localProvider)
 	})
+}
+
+func TestNewProvider(t *testing.T) {
+	t.Parallel()
 
 	t.Run("failed", func(t *testing.T) {
 		t.Parallel()
 
-		err := os.Unsetenv("LOCAL_PATH")
-		sdktesting.IsNull(t, err)
-
-		_, err = local.NewProvider()
+		_, err := local.NewProvider()
 		sdktesting.IsNotNull(t, err)
 		sdktesting.Equals(t, err.Error(), "missing env LOCAL_PATH")
 	})

--- a/pkg/storage/local/provider_test.go
+++ b/pkg/storage/local/provider_test.go
@@ -1,14 +1,35 @@
 package local_test
 
 import (
+	"fmt"
+	"os"
 	"testing"
 
 	sdktesting "gosdk/internal/testing"
 	"gosdk/pkg/storage/local"
 )
 
+func checkEnvVariables(provider string, variables []string) error {
+	for _, v := range variables {
+		if os.Getenv(v) == "" {
+			return fmt.Errorf("missing %s environment variable %s", provider, v)
+		}
+	}
+
+	return nil
+}
+
+func setupEnv() error {
+	return checkEnvVariables("local", []string{"LOCAL_PATH"})
+}
+
 func TestNewProvider(t *testing.T) {
 	t.Parallel()
+
+	if err := setupEnv(); err != nil {
+		t.Logf("Failed to setup provider: %v", err)
+		t.Fail()
+	}
 
 	t.Run("success", func(t *testing.T) {
 		t.Parallel()
@@ -23,6 +44,6 @@ func TestNewProvider(t *testing.T) {
 
 		_, err := local.NewProvider()
 		sdktesting.IsNotNull(t, err)
-		sdktesting.Equals(t, err.Error(), "not implemented")
+		sdktesting.Equals(t, err.Error(), "missing env LOCAL_PATH")
 	})
 }

--- a/pkg/storage/local/provider_test.go
+++ b/pkg/storage/local/provider_test.go
@@ -1,6 +1,7 @@
 package local_test
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"testing"
@@ -9,10 +10,12 @@ import (
 	"gosdk/pkg/storage/local"
 )
 
+var errMissingEnvironmentVariable = errors.New("missing environment variable")
+
 func checkEnvVariables(provider string, variables []string) error {
 	for _, v := range variables {
 		if os.Getenv(v) == "" {
-			return fmt.Errorf("missing %s environment variable %s", provider, v)
+			return fmt.Errorf("%w: %s provider, variable %s", errMissingEnvironmentVariable, provider, v)
 		}
 	}
 

--- a/pkg/storage/local/provider_test.go
+++ b/pkg/storage/local/provider_test.go
@@ -1,0 +1,14 @@
+package local_test
+
+import (
+	sdktesting "gosdk/internal/testing"
+	"gosdk/pkg/storage/local"
+	"testing"
+)
+
+func TestNewProvider(t *testing.T) {
+	t.Parallel()
+
+	_, err := local.NewProvider()
+	sdktesting.IsNotNull(t, err)
+}

--- a/pkg/storage/local/provider_test.go
+++ b/pkg/storage/local/provider_test.go
@@ -1,22 +1,28 @@
 package local_test
 
 import (
+	"testing"
+
 	sdktesting "gosdk/internal/testing"
 	"gosdk/pkg/storage/local"
-	"testing"
 )
 
 func TestNewProvider(t *testing.T) {
 	t.Parallel()
 
 	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
 		localProvider, err := local.NewProvider()
 		sdktesting.IsNull(t, err)
 		sdktesting.IsNotNull(t, localProvider)
 	})
 
 	t.Run("failed", func(t *testing.T) {
+		t.Parallel()
+
 		_, err := local.NewProvider()
 		sdktesting.IsNotNull(t, err)
+		sdktesting.Equals(t, err.Error(), "not implemented")
 	})
 }

--- a/pkg/storage/local/provider_test.go
+++ b/pkg/storage/local/provider_test.go
@@ -29,13 +29,11 @@ func setupEnv() error {
 func TestNewProvider(t *testing.T) {
 	t.Parallel()
 
-	if err := setupEnv(); err != nil {
-		t.Logf("Failed to setup provider: %v", err)
-		t.Fail()
-	}
-
 	t.Run("success", func(t *testing.T) {
 		t.Parallel()
+
+		err := os.Setenv("LOCAL_PATH", "/tmp")
+		sdktesting.IsNull(t, err)
 
 		localProvider, err := local.NewProvider()
 		sdktesting.IsNull(t, err)
@@ -45,7 +43,10 @@ func TestNewProvider(t *testing.T) {
 	t.Run("failed", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := local.NewProvider()
+		err := os.Unsetenv("LOCAL_PATH")
+		sdktesting.IsNull(t, err)
+
+		_, err = local.NewProvider()
 		sdktesting.IsNotNull(t, err)
 		sdktesting.Equals(t, err.Error(), "missing env LOCAL_PATH")
 	})

--- a/pkg/storage/local/provider_test.go
+++ b/pkg/storage/local/provider_test.go
@@ -9,6 +9,14 @@ import (
 func TestNewProvider(t *testing.T) {
 	t.Parallel()
 
-	_, err := local.NewProvider()
-	sdktesting.IsNotNull(t, err)
+	t.Run("success", func(t *testing.T) {
+		localProvider, err := local.NewProvider()
+		sdktesting.IsNull(t, err)
+		sdktesting.IsNotNull(t, localProvider)
+	})
+
+	t.Run("failed", func(t *testing.T) {
+		_, err := local.NewProvider()
+		sdktesting.IsNotNull(t, err)
+	})
 }

--- a/pkg/storage/provider_test.go
+++ b/pkg/storage/provider_test.go
@@ -3,6 +3,7 @@ package storage_test
 import (
 	"context"
 	"errors"
+	"os"
 	"testing"
 
 	sdktesting "gosdk/internal/testing"
@@ -40,7 +41,12 @@ func TestNew(t *testing.T) {
 		{
 			name:   types.Local,
 			want:   false,
-			errMsg: "failed to create local Provider: not implemented",
+			errMsg: "failed to create local Provider: missing env LOCAL_PATH",
+		},
+		{
+			name:   types.Local,
+			want:   true,
+			errMsg: "",
 		},
 		{
 			name:   "wrong",
@@ -52,6 +58,16 @@ func TestNew(t *testing.T) {
 	for _, testCase := range tests {
 		t.Run(string(testCase.name), func(t *testing.T) {
 			t.Parallel()
+
+			if testCase.want {
+				err := os.Setenv("LOCAL_PATH", "/tmp")
+				sdktesting.IsNull(t, err)
+			}
+
+			if !testCase.want {
+				err := os.Unsetenv("LOCAL_PATH")
+				sdktesting.IsNull(t, err)
+			}
 
 			provider, err := storage.New(testCase.name)
 


### PR DESCRIPTION
This commit introduces a test for the `NewProvider` function within the local storage package. It ensures that the provider creation logic behaves as expected and errors are not nil when invoked.